### PR TITLE
Return `Future` from `mcp-server` `Router`; handle server ping

### DIFF
--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -1,5 +1,5 @@
 use mcp_core::protocol::{
-    CallToolResult, GetPromptResult, Implementation, InitializeResult, JsonRpcError,
+    CallToolResult, EmptyResult, GetPromptResult, Implementation, InitializeResult, JsonRpcError,
     JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, ListPromptsResult,
     ListResourcesResult, ListToolsResult, ReadResourceResult, ServerCapabilities, METHOD_NOT_FOUND,
 };
@@ -97,6 +97,8 @@ pub trait McpClientTrait: Send + Sync {
     async fn list_prompts(&self, next_cursor: Option<String>) -> Result<ListPromptsResult, Error>;
 
     async fn get_prompt(&self, name: &str, arguments: Value) -> Result<GetPromptResult, Error>;
+
+    async fn ping(&self) -> Result<EmptyResult, Error>;
 }
 
 /// The MCP client is the interface for MCP operations.
@@ -387,5 +389,11 @@ where
         let params = serde_json::json!({ "name": name, "arguments": arguments });
 
         self.send_request("prompts/get", params).await
+    }
+
+    async fn ping(&self) -> Result<EmptyResult, Error> {
+        let params = serde_json::json!({});
+
+        self.send_request("ping", params).await
     }
 }

--- a/crates/mcp-core/src/protocol.rs
+++ b/crates/mcp-core/src/protocol.rs
@@ -53,6 +53,7 @@ pub enum JsonRpcMessage {
     Response(JsonRpcResponse),
     Notification(JsonRpcNotification),
     Error(JsonRpcError),
+    Empty(EmptyResult),
     Nil, // used to respond to notifications
 }
 
@@ -234,7 +235,7 @@ pub struct GetPromptResult {
     pub messages: Vec<PromptMessage>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct EmptyResult {}
 
 #[cfg(test)]

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -199,6 +199,7 @@ where
                         JsonRpcMessage::Response(_)
                         | JsonRpcMessage::Notification(_)
                         | JsonRpcMessage::Nil
+                        | JsonRpcMessage::Empty(_)
                         | JsonRpcMessage::Error(_) => {
                             // Ignore responses, notifications and nil messages for now
                             continue;

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -416,7 +416,7 @@ impl<T> Service<JsonRpcRequest> for RouterService<T>
 where
     T: Router + Clone + Send + Sync + 'static,
 {
-    type Response = JsonRpcMessage;
+    type Response = JsonRpcResponse;
     type Error = BoxError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
@@ -447,7 +447,7 @@ where
                     Ok(response)
                 }
             };
-            result.map(JsonRpcMessage::Response).map_err(BoxError::from)
+            result.map_err(BoxError::from)
         })
     }
 }

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -61,43 +61,48 @@ impl mcp_server::Router for CounterRouter {
             .build()
     }
 
-    fn list_tools(&self) -> Vec<Tool> {
-        vec![
-            Tool::new(
-                "increment".to_string(),
-                "Increment the counter by 1".to_string(),
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }),
-            ),
-            Tool::new(
-                "decrement".to_string(),
-                "Decrement the counter by 1".to_string(),
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }),
-            ),
-            Tool::new(
-                "get_value".to_string(),
-                "Get the current counter value".to_string(),
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }),
-            ),
-        ]
+    fn list_tools(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<mcp_core::tool::Tool>, ToolError>> + Send + 'static>>
+    {
+        Box::pin(async move {
+            Ok(vec![
+                Tool::new(
+                    "increment".to_string(),
+                    "Increment the counter by 1".to_string(),
+                    serde_json::json!({
+                        "type": "object",
+                        "properties": {},
+                        "required": []
+                    }),
+                ),
+                Tool::new(
+                    "decrement".to_string(),
+                    "Decrement the counter by 1".to_string(),
+                    serde_json::json!({
+                        "type": "object",
+                        "properties": {},
+                        "required": []
+                    }),
+                ),
+                Tool::new(
+                    "get_value".to_string(),
+                    "Get the current counter value".to_string(),
+                    serde_json::json!({
+                        "type": "object",
+                        "properties": {},
+                        "required": []
+                    }),
+                ),
+            ])
+        })
     }
 
     fn call_tool(
         &self,
         tool_name: &str,
         _arguments: Value,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ToolError>> + Send + 'static>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ToolError>> + Send + '_>> {
         let this = self.clone();
         let tool_name = tool_name.to_string();
 
@@ -120,17 +125,21 @@ impl mcp_server::Router for CounterRouter {
         })
     }
 
-    fn list_resources(&self) -> Vec<Resource> {
-        vec![
-            self._create_resource_text("str:////Users/to/some/path/", "cwd"),
-            self._create_resource_text("memo://insights", "memo-name"),
-        ]
+    fn list_resources(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Resource>, ToolError>> + Send + '_>> {
+        Box::pin(async move {
+            Ok(vec![
+                self._create_resource_text("str:////Users/to/some/path/", "cwd"),
+                self._create_resource_text("memo://insights", "memo-name"),
+            ])
+        })
     }
 
     fn read_resource(
         &self,
         uri: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<String, ResourceError>> + Send + 'static>> {
+    ) -> Pin<Box<dyn Future<Output = Result<String, ResourceError>> + Send + '_>> {
         let uri = uri.to_string();
         Box::pin(async move {
             match uri.as_str() {
@@ -151,22 +160,26 @@ impl mcp_server::Router for CounterRouter {
         })
     }
 
-    fn list_prompts(&self) -> Vec<Prompt> {
-        vec![Prompt::new(
-            "example_prompt",
-            Some("This is an example prompt that takes one required agrument, message"),
-            Some(vec![PromptArgument {
-                name: "message".to_string(),
-                description: Some("A message to put in the prompt".to_string()),
-                required: Some(true),
-            }]),
-        )]
+    fn list_prompts(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Prompt>, ToolError>> + Send + '_>> {
+        Box::pin(async move {
+            Ok(vec![Prompt::new(
+                "example_prompt",
+                Some("This is an example prompt that takes one required agrument, message"),
+                Some(vec![PromptArgument {
+                    name: "message".to_string(),
+                    description: Some("A message to put in the prompt".to_string()),
+                    required: Some(true),
+                }]),
+            )])
+        })
     }
 
     fn get_prompt(
         &self,
         prompt_name: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<String, PromptError>> + Send + 'static>> {
+    ) -> Pin<Box<dyn Future<Output = Result<String, PromptError>> + Send + '_>> {
         let prompt_name = prompt_name.to_string();
         Box::pin(async move {
             match prompt_name.as_str() {


### PR DESCRIPTION
## 🗣 Description
 - Handle client/server ping.
 - Use `Future` for server trait. Allows for list operations to use `.await`. e.g.
     ```rust
     fn list_tools(
        &self,
    ) -> Pin<Box<dyn Future<Output = Result<Vec<mcp_core::tool::Tool>, ToolError>> + Send + '_>>
    {
        Box::pin(async move {
           foo().await
    ``` 

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
